### PR TITLE
Fix a couple of its/it's errors.

### DIFF
--- a/chapters/chap06-traps.rst
+++ b/chapters/chap06-traps.rst
@@ -7,7 +7,7 @@ It's a trap!
 
 Traps form the majority of many people’s defences, so it’s best we get
 sorted and make some. First up, we will need a lot of mechanisms, so go
-find that mechanic’s workshop and fill it’s job queue with mechanisms.
+find that mechanic’s workshop and fill its job queue with mechanisms.
 They’ll end up in a finished goods pile when done.
 
 Next, go to the Carpenter’s workshop and add a ton of cages (:kbd:`j` is the

--- a/misc/contributing.rst
+++ b/misc/contributing.rst
@@ -86,7 +86,7 @@ Style
 -----
 Use clear, direct, and simple language.  Avoid jargon or the passive voice.
 I find the `hemmingway editor <http://www.hemingwayapp.com>`_ useful;
-I often ignore but always consider it's suggestions.
+I often ignore but always consider its suggestions.
 
 Keep all lines to 80 characters or less.  Sphinx will automatically join
 everything between blank lines into one paragraph, and short lines


### PR DESCRIPTION
It was made slightly tricky to check for all instances of this, because there are a mixture of ASCII apostrophes with U+2019 "right single quotation mark" in the documents.  But I think I managed to "catch 'em all".  I didn't find any instances of U+02BC "modifier letter apostrophe".

Thanks for the guide!  I hope you find this patch helpful.